### PR TITLE
Client mount

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,4 @@
 import { h, render } from 'preact';
 import App from '../views/index'
 
-render(<App state={window.__INITIAL_STATE} />, document.body)
+render(<App state={window.__INITIAL_STATE} />, document.body, document.body.firstElementChild)

--- a/src/server/routes/Web.js
+++ b/src/server/routes/Web.js
@@ -12,13 +12,13 @@ router.get('/about',  (req, res) => {
   res.send(`
     <html>
     <head>
+    </head>
+    <body>
+      ${render(<App url={req.originalUrl} state={state} />)}
       <script>
         window.__INITIAL_STATE = ${JSON.stringify(state)}
       </script>
       <script src="bundle.js" /></script>
-    </head>
-    <body>
-    ${render(<App url={req.originalUrl} state={state} />)}
     </body>
     </html>
   `)


### PR DESCRIPTION
1. Move bundle import to the bottom of the page.

    > This makes sure document.body exists when it loads, and also ensures the server-rendered HTML is the first element within `<body>` so we can pick it up on the client.
2. Attempt to attach to the first element within body

    > using `firstElementChild` instead of `firstChild` to ignore whitespace and comments